### PR TITLE
Fix press kit meta description

### DIFF
--- a/press/index.html
+++ b/press/index.html
@@ -4,7 +4,7 @@
 		<meta charset="UTF-8">
 		<title>Mercury Weather • Press Kit</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-		<meta name="description" content="A nicely designed native time tracking and invoicing app.">
+                <meta name="description" content="A nicely designed weather app.">
 		<link rel="stylesheet" href="main.css">
 	
 		<link rel="canonical" href="https://mercuryweather.app">


### PR DESCRIPTION
## Summary
- fix incorrect meta description on press page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f5b3cbde88330bbf1437306169a71